### PR TITLE
Do not replace when variable is not found

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,15 @@ function resolveVar(v){
     if (variablesFile && variablesObj == null){
         initVariablesObj();
     }
+    
+    let replacement = []
+    
     if (variablesFileType == "xml"){
-        return resolveXMLVar(v);
+        replacement = resolveXMLVar(v);
     }else if (variablesFileType == "json"){
-        return resolveJSONVar(v);
+        replacement = resolveJSONVar(v);
     }
-    return "${"+v+"}"
+    return replacement.length === 0 ? "${"+v+"}" : replacement
 }
 
 function resolveJSONVar(v){


### PR DESCRIPTION
This attempts to fix a problem that JS string interpolation inside code blocks gets all replaced with the variables. It essentially replaces them with empty string everywhere unless the interpolated variable is also present in the variables file.

So, if a variable is not present, the original `${foo}` is echoed